### PR TITLE
Add arm64 support using buildx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,22 @@
 sudo: required
+
+dist: focal
+
 services:
   - docker
 
+before_script:
+  - mkdir -p ~/.docker/cli-plugins
+  - wget -O - https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+  - chmod a+x ~/.docker/cli-plugins/docker-buildx
+  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  - docker buildx create --use --name mybuilder
+
 script:
-  - echo "Build local image"
-  - docker build -t filebeat .
-  - docker images
-  - echo "Run local image"
-  - docker run -d --name filebeat filebeat
-  - docker ps -a
-  - docker logs filebeat
+  - echo "Build and push both amd64 and arm64 images"
+  - docker login -u ${USERNAME} -p ${PASSWORD}
+  - docker buildx build --platform linux/amd64,linux/arm64 -t nguoianphu/docker-filebeat:latest --push .
   - echo "Testing public image on Docker Hub"
   - docker run -d --name nguoianphu-filebeat nguoianphu/docker-filebeat
   - docker ps -a
-  - docker logs nguoianphu-filebeat  
-  - docker images
+  - docker logs nguoianphu-filebeat

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 # Alpine OS 3.4
 # http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/
-FROM alpine:3.4
+FROM alpine:latest
 
 MAINTAINER Tuan Vo <vohungtuan@gmail.com>
 
@@ -13,25 +13,29 @@ MAINTAINER Tuan Vo <vohungtuan@gmail.com>
 #                                INSTALLATION
 ###############################################################################
 
-ENV FILEBEAT_VERSION=5.0.0
+ENV FILEBEAT_VERSION=7.14.0
 
-RUN set -x \
- && apk add --update bash \
-                     curl \
-                     tar \
-					 openssl \                    
- && curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz \
- && tar xzvf filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz -C / --strip-components=1 \
- && rm -rf filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz \
- && apk --no-cache add ca-certificates \
- && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
- && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk \
- && apk add glibc-2.23-r3.apk \
- && apk del curl \
-            tar \
-			openssl \
- && rm -rf /var/cache/apk/*
- 
+RUN if [ `uname -m` = "aarch64" ] ; then \
+       arch="arm64"; \
+    else \
+       arch="x86_64"; \
+    fi \
+    && set -x \
+    && apk add --update bash \
+                        curl \
+                        tar \
+                        openssl \
+    && curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-linux-${arch}.tar.gz \
+    && tar xzvf filebeat-${FILEBEAT_VERSION}-linux-${arch}.tar.gz -C / --strip-components=1 \
+    && rm -rf filebeat-${FILEBEAT_VERSION}-linux-${arch}.tar.gz \
+    && apk --no-cache add ca-certificates \
+    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
+    && apk add glibc-2.34-r0.apk \
+    && apk del curl \
+               tar \
+               openssl \
+    && rm -rf /var/cache/apk/*
 ###############################################################################
 #                                   START
 ############################################################################### 


### PR DESCRIPTION
The following file has been created and modified:
Modified Dockerfile to make it compatible with both arm64 and amd64 platforms.
Added buildx support to build and push the image for both amd64 and arm64 platforms.

Signed-off-by: odidev odidev@puresoftware.com